### PR TITLE
notebook pulls from fluree server instead of http-api-gateway

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,9 +25,9 @@ services:
       - fluree
 
   fluree:
-    image: fluree/http-api-gateway:latest
+    image: fluree/server:latest
     ports:
       - "58090:8090"
     volumes:
-      - "./data:/opt/fluree-http-api-gateway/data"
+      - "./data:/opt/fluree-server/data"
 


### PR DESCRIPTION
per this announcement https://fluree-internal.slack.com/archives/CKYRKUN0Y/p1698329851347349 pull from fluree/server with 'new maybe final' version of syntax